### PR TITLE
Explain push notifications for watch functionality

### DIFF
--- a/Haptic Metronome Countdown Watch App/HapticTimerView.swift
+++ b/Haptic Metronome Countdown Watch App/HapticTimerView.swift
@@ -96,6 +96,16 @@ struct HapticTimerView: View {
                 // The extended runtime session should keep the timer running
             }
             #endif
+            .alert("Enable Notifications", isPresented: $viewModel.showNotificationExplanationDialog) {
+                Button("Allow") {
+                    viewModel.requestNotificationPermissionAfterExplanation()
+                }
+                Button("Cancel", role: .cancel) {
+                    viewModel.cancelNotificationPermissionRequest()
+                }
+            } message: {
+                Text("To keep your WatchOS app running and deliver haptic feedback even when your watch goes to sleep, this app needs notification permissions. This ensures your timer continues working in the background.")
+            }
         }
     }
 

--- a/Haptic-Timer/HapticTimerView.swift
+++ b/Haptic-Timer/HapticTimerView.swift
@@ -76,6 +76,16 @@ struct HapticTimerView: View {
                     viewModel.setTime(initialTime)
                 }
             }
+            .alert("Enable Notifications", isPresented: $viewModel.showNotificationExplanationDialog) {
+                Button("Allow") {
+                    viewModel.requestNotificationPermissionAfterExplanation()
+                }
+                Button("Cancel", role: .cancel) {
+                    viewModel.cancelNotificationPermissionRequest()
+                }
+            } message: {
+                Text("To keep your WatchOS app running and deliver haptic feedback even when your watch goes to sleep, this app needs notification permissions. This ensures your timer continues working in the background.")
+            }
         }
     }
     


### PR DESCRIPTION
Add a pre-permission dialog for push notifications to explain their necessity for WatchOS background operation and haptic feedback.